### PR TITLE
Remove okhttp dependency from dd-trace-ot

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -42,8 +42,8 @@ dependencies {
   api group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
 
   api deps.slf4j
-  api group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.12'
-  api deps.okio
+  // api group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.12'
+  // api deps.okio
 
   testImplementation project(":dd-java-agent:testing")
 


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
